### PR TITLE
Linear velocity fix for motors

### DIFF
--- a/packages/visual_lane_servoing/src/visual_lane_servoing_node.py
+++ b/packages/visual_lane_servoing/src/visual_lane_servoing_node.py
@@ -38,7 +38,7 @@ class LaneServoingNode(DTROS):
         # get the name of the robot
         self.veh = rospy.get_namespace().strip("/")
 
-        self.v_0 = 0.15  # Forward velocity command
+        self.v_0 = 0.3  # Forward velocity command
 
         # The following are used for scaling
         self.steer_max = -1


### PR DESCRIPTION
Increased linear velocity from 0.15 to 0.3 to prevent motors to get stucked and not move when gain <=1