### PR TITLE
Update horizon mask to use the value directly instead of `h - horizon`

### DIFF
--- a/notebooks/04-Visual-Servoing/visual_servoing.ipynb
+++ b/notebooks/04-Visual-Servoing/visual_servoing.ipynb
@@ -161,7 +161,7 @@
     "h, w = img.shape\n",
     "\n",
     "mask_ground = np.zeros((h, w), dtype=np.uint8)\n",
-    "mask_ground[int(h - horizon) :, :] = 1\n",
+    "mask_ground[int(horizon) :, :] = 1\n",
     "\n",
     "fig = plt.figure(figsize = (30,20))\n",
     "ax1 = fig.add_subplot(1,4,1)\n",


### PR DESCRIPTION
The coordinate frame used for the homography follows the cv2 convention. So the mask can use the horizon value directly instead of `h - horizon`. 